### PR TITLE
fix: handle non-string segments in proxy path processing

### DIFF
--- a/packages/better-auth/src/client/proxy.ts
+++ b/packages/better-auth/src/client/proxy.ts
@@ -65,6 +65,7 @@ export function createDynamicPathProxy<T extends Record<string, any>>(
 				const routePath =
 					"/" +
 					path
+						.filter((segment) => typeof segment === "string")
 						.map((segment) =>
 							segment.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`),
 						)


### PR DESCRIPTION
## Summary
- Fix TypeError when `segment.replace` is called on non-string values in the proxy path processing
- Add type guard to filter out non-string segments before applying string operations

## Problem
The error `TypeError: segment.replace is not a function` occurs when the path array contains non-string values (like symbols or other types). The code was attempting to call `.replace()` on these non-string values without checking their type first.

## Solution
Added a `.filter()` call to ensure only string segments are processed before applying the `.replace()` method for kebab-case conversion.

## Test plan
- [ ] Verify that proxy path processing works correctly with string segments
- [ ] Confirm no errors occur when path contains non-string values
- [ ] Test that API calls through the proxy still function as expected

🤖 Generated with [Claude Code](https://claude.ai/code)